### PR TITLE
Fix: Export initializeSupported() API in nimbuild-corejs

### DIFF
--- a/packages/nimbuild-corejs/README.md
+++ b/packages/nimbuild-corejs/README.md
@@ -27,6 +27,7 @@ Import module, configure, and prime cache
 const {
     addSupported,
     clearSupported,
+    initializeSupported,
     primeCache,
     serializeCache,
     deserializeCache

--- a/packages/nimbuild-corejs/lib/index.js
+++ b/packages/nimbuild-corejs/lib/index.js
@@ -7,6 +7,7 @@ const {
     addSupported,
     clearSupported,
     getSupported,
+    initializeSupported,
     getBaseFeatureModules
 } = require('./supported-sets');
 const webpacknimbuild = require('@vrbo/nimbuild-webpack')({
@@ -111,6 +112,7 @@ module.exports = {
     getPolyfillString,
     addSupported,
     clearSupported,
+    initializeSupported,
     getSupported,
     primeCache,
     serializeCache: () => {

--- a/packages/nimbuild-corejs/lib/tests/index.test.js
+++ b/packages/nimbuild-corejs/lib/tests/index.test.js
@@ -3,14 +3,12 @@ const {
     clearCache,
     serializeCache,
     deserializeCache,
-    primeCache
-} = require('../index');
-const {
     getSupported,
     clearSupported,
     addSupported,
-    initializeSupported
-} = require('../supported-sets');
+    initializeSupported,
+    primeCache
+} = require('../index');
 const mockuas = require('../mocks/ua.mock');
 
 let mockFail = false;


### PR DESCRIPTION
Fix: Export initializeSupported() API in nimbuild-corejs

## Description

Fix: Export initializeSupported() API in nimbuild-corejs

## Motivation and Context

InitializeSupported() is a required API to use `nimbuild-corejs`

## How Has This Been Tested?

Updated index.test to use primary exports

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
